### PR TITLE
setup.py: fail if using anything but Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from setuptools import setup, find_packages
+
+
+if sys.version_info[0] != 2:
+    sys.exit("This package only supports Python 2.")
 
 requirements = [
     # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)
@@ -81,4 +87,7 @@ setup(
             "confidant-format = confidant_client.formatter:main"
         ],
     },
+    classifiers=[
+        'Programming Language :: Python :: 2 :: Only',
+    ],
 )


### PR DESCRIPTION
This client doesn't work on Python 3. The most obvious incompatibilities are all of the print statements, but there may be much more. For the time being, you should probably warn people off from trying. With this change, this is the behavior I get when attempting to install on Python 3:

> $ python3 setup.py install
> This package only supports Python 2.
> FAIL: 1
