### PR TITLE
allow specifying an endpoint_url override

### DIFF
--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -143,7 +143,9 @@ class ConfidantClient(object):
         )
         self.kms_client = confidant_client.services.get_boto_client(
             'kms',
-            region=self.config['region']
+            region=self.config['region'],
+            endpoint_url=self.config['kms_endpoint_url']
+
         )
         if self.config['assume_role']:
             self.aws_creds = self._get_assume_role_creds(
@@ -375,7 +377,8 @@ class ConfidantClient(object):
                 region=self.config['region'],
                 aws_access_key_id=self.aws_creds['AccessKeyId'],
                 aws_secret_access_key=self.aws_creds['SecretAccessKey'],
-                aws_session_token=self.aws_creds['SessionToken']
+                aws_session_token=self.aws_creds['SessionToken'],
+                endpoint_url=self.config['kms_endpoint_url']
             )
         else:
             _kms_client = self.kms_client

--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -50,7 +50,8 @@ class ConfidantClient(object):
             retries=None,
             backoff=None,
             config_files=None,
-            profile=None
+            profile=None,
+            kms_endpoint_url=None
             ):
         """Create a ConfidantClient object.
 
@@ -78,6 +79,8 @@ class ConfidantClient(object):
             configuration from. First file found will be used. Default:
                 ['~/.confidant', '/etc/confidant/config']
             profile: profile to read config values from.
+            kms_endpoint_url: A URL to override the default endpoint used to
+                access the KMS service. Default: None
         """
         # Set defaults
         self.config = {
@@ -90,7 +93,8 @@ class ConfidantClient(object):
             'assume_role': None,
             'region': None,
             'retries': 0,
-            'backoff': 1
+            'backoff': 1,
+            'kms_endpoint_url': None
         }
         if config_files is None:
             config_files = ['~/.confidant', '/etc/confidant/config']
@@ -108,7 +112,8 @@ class ConfidantClient(object):
             'token_cache_file': token_cache_file,
             'region': region,
             'backoff': backoff,
-            'assume_role': assume_role
+            'assume_role': assume_role,
+            'kms_endpoint_url': kms_endpoint_url
         }
         for key, val in args_config.iteritems():
             if val is not None:
@@ -157,7 +162,8 @@ class ConfidantClient(object):
                 token_version=self.config['token_version'],
                 token_cache_file=self.config['token_cache_file'],
                 token_lifetime=self.config['token_lifetime'],
-                aws_creds=self.aws_creds
+                aws_creds=self.aws_creds,
+                endpoint_url=self.config['kms_endpoint_url']
             )
         except kmsauth.ConfigurationError:
             raise ClientConfigurationError('Error configuring kmsauth client.')

--- a/confidant_client/cli.py
+++ b/confidant_client/cli.py
@@ -43,7 +43,8 @@ def _get_client_from_args(args):
         region=args.region,
         retries=args.retries,
         config_files=config_files,
-        profile=args.profile
+        profile=args.profile,
+        kms_endpoint_url=args.kms_endpoint_url
     )
     return client
 
@@ -132,6 +133,10 @@ def _parse_args():
     parser.add_argument(
         '--region',
         help='Use the specified region for authentication.'
+    )
+    parser.add_argument(
+        '--kms-endpoint-url',
+        help='Use a different endpoint url for the KMS service.'
     )
     parser.add_argument(
         '--log-level',

--- a/confidant_client/services/__init__.py
+++ b/confidant_client/services/__init__.py
@@ -11,10 +11,11 @@ def get_boto_client(
         region=None,
         aws_access_key_id=None,
         aws_secret_access_key=None,
-        aws_session_token=None
+        aws_session_token=None,
+        endpoint_url=None
         ):
     """Get a boto3 client connection."""
-    cache_key = '{0}:{1}:{2}'.format(client, region, aws_access_key_id)
+    cache_key = '{0}:{1}:{2}:{3}'.format(client, region, aws_access_key_id, endpoint_url)
     if not aws_session_token:
         if cache_key in CLIENT_CACHE:
             return CLIENT_CACHE[cache_key]
@@ -28,7 +29,7 @@ def get_boto_client(
         logging.error("Failed to get {0} client.".format(client))
         return None
 
-    CLIENT_CACHE[cache_key] = session.client(client)
+    CLIENT_CACHE[cache_key] = session.client(client, endpoint_url=endpoint_url)
     return CLIENT_CACHE[cache_key]
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
     # Licence: Apache2
     # Upstream url: https://github.com/lyft/python-kmsauth
     # Use: client authentication to confidant
-    'kmsauth>=0.1.6,<1.0.0',
+    'kmsauth>=0.2.0,<1.0.0',
 
     # Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
     # License: BSD


### PR DESCRIPTION
KMS doesn't have in-VPC endpoints yet, so we need to be able to proxy our KMS requests through a known host in order to meaningfully restrict egress from our machines. This pull request allows overriding the KMS endpoint used by the AWS bindings. This relies on https://github.com/lyft/python-kmsauth/pull/11 and so will also require a dependency bump once that is released.