### PR TITLE
Pass along error message from kms error

### DIFF
--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -171,7 +171,8 @@ class ConfidantClient(object):
             )
         except kmsauth.ConfigurationError as e:
             kms_msg = str(e)
-            raise ClientConfigurationError('Error configuring kmsauth client: %s' % kms_msg)
+            raise ClientConfigurationError('Error configuring kmsauth client: '
+                                           + kms_msg)
 
     def _load_config(self, config_files, profile):
         """Initialize client settings from config."""

--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -169,8 +169,9 @@ class ConfidantClient(object):
                 token_lifetime=self.config['token_lifetime'],
                 aws_creds=self.aws_creds
             )
-        except kmsauth.ConfigurationError:
-            raise ClientConfigurationError('Error configuring kmsauth client.')
+        except kmsauth.ConfigurationError as e:
+            kms_msg = str(e)
+            raise ClientConfigurationError('Error configuring kmsauth client: %s' % kms_msg)
 
     def _load_config(self, config_files, profile):
         """Initialize client settings from config."""


### PR DESCRIPTION
Changes the errors raised from "Error configuring kmsauth client" to something actionable like "Error configuring kmsauth client: user_type missing from auth_context."