### PR TITLE
Require newer boto3 and remove pyopenssl workaround

### DIFF
--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -16,7 +16,6 @@ from cryptography.fernet import Fernet
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry
 
-import confidant_client.workarounds  # noqa
 import confidant_client.services
 from confidant_client.lib import cryptolib
 

--- a/confidant_client/workarounds.py
+++ b/confidant_client/workarounds.py
@@ -1,8 +1,0 @@
-# https://github.com/boto/botocore/issues/760
-# https://github.com/boto/boto3/issues/220#issuecomment-171477361
-from __future__ import absolute_import
-try:
-    from botocore.vendored.requests.packages.urllib3.contrib import pyopenssl
-    pyopenssl.extract_from_urllib3()
-except ImportError:
-    pass

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     # License: Apache2
     # Upstream url: https://github.com/boto/boto3
     # Use: For KMS
-    'boto3>=1.2.0,<2.0.0',
+    'boto3>=1.2.6,<2.0.0',
 
     # cryptography is a package which provides cryptographic recipes and
     # primitives to Python developers.


### PR DESCRIPTION
https://github.com/boto/botocore/pull/803 was merged and released in 1.3.30

[boto3@1.2.6:setup.py](https://github.com/boto/boto3/blob/1.2.6/setup.py) requires `botocore>=1.4`