### PR TITLE
Command line tool to launch processes with creds as env var

### DIFF
--- a/confidant_client/cli.py
+++ b/confidant_client/cli.py
@@ -645,7 +645,7 @@ class _HelpAction(argparse._HelpAction):
             'example: confidant get_service -u'
             ' "https://confidant-production.example.com" -k'
             ' "alias/authnz-production" --from myservice-production'
-            ' --to confidant-production --user_type service'
+            ' --to confidant-production --user-type service'
             ' --region us-west-2 --service myservice-production'
         )
 

--- a/confidant_client/env.py
+++ b/confidant_client/env.py
@@ -1,0 +1,51 @@
+
+import os
+import click
+import sys
+from typing import Dict
+from confidant_client import ConfidantClient
+from kmsauth import TokenGenerationError
+
+
+def format_cred_key(key: str, prefix: str) -> str:
+    return f"{prefix}{key}".upper()
+
+
+def get_service(
+        client: ConfidantClient,
+        service: str,
+        prefix: str) -> Dict[str, str]:
+    try:
+        ret = client.get_service(service)
+    except TokenGenerationError:
+        sys.exit("Unable to locate AWS credentials.")
+
+    cred_pairs = {}
+    for cred in ret['service']['credentials']:
+        for k, v in cred['credential_pairs'].items():
+            cred_pairs[format_cred_key(k, prefix)] = v
+    return cred_pairs
+
+
+@click.command()
+@click.option('--service', type=str, required=True, default="",
+              help="Get all credential pairs of this service")
+@click.option('--prefix', type=str, required=False, default="CREDENTIALS_",
+              help="Prepend env keys with this prefix")
+@click.argument("command", nargs=-1, required=True)
+def exec(command, service, prefix):
+    """Gets credentials from Confidant and launch process
+    with these credentials as env vars
+    """
+    client = ConfidantClient()
+    cred_pairs = get_service(client=client, service=service, prefix=prefix)
+    environment_vars = {**os.environ, **cred_pairs}
+    os.execvpe(command[0], command, environment_vars)
+
+
+def main():
+    exec()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="confidant-client",
-    version="2.2.0",
+    version="2.2.1",
     packages=find_packages(exclude=["test*"]),
     install_requires=[
         # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)
@@ -93,7 +93,8 @@ setup(
     entry_points={
         "console_scripts": [
             "confidant = confidant_client.cli:main",
-            "confidant-format = confidant_client.formatter:main"
+            "confidant-format = confidant_client.formatter:main",
+            "confidant-env = confidant_client.env:main"
         ],
     },
     classifiers=[


### PR DESCRIPTION
```
confidant-env --help
Usage: confidant-env [OPTIONS] COMMAND...

  Gets credentials from Confidant and launch process with these credentials as
  env vars

Options:
  --service TEXT  Get all credential pairs of this service  [required]
  --prefix TEXT   Prepend env keys with this prefix
  --help          Show this message and exit.
```

Ex:
`confidant-env --service testservice-staging-iad -- env`