### PR TITLE
Allow confidant CLI to be wrapped by command defined in command_wrap

### DIFF
--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -61,7 +61,8 @@ class ConfidantClient(object):
             config_files=None,
             profile=None,
             verify=None,
-            timeout=None
+            timeout=None,
+            command_wrap=None,
             ):
         """Create a ConfidantClient object.
 
@@ -91,6 +92,10 @@ class ConfidantClient(object):
             profile: profile to read config values from.
             verify:  Whether we verify the servers TLS certificate.
             timeout: Connect and read timeout in seconds. Default: 5
+            command_wrap: command in string format to run before confidant.
+                Useful when authentication to AWS needs to occur to generate
+                temporary credentials.  Examples: aws-vault, saml2aws
+                Default None.
         """
         # Set defaults
         self.config = {
@@ -106,6 +111,7 @@ class ConfidantClient(object):
             'backoff': 1,
             'verify': True,
             'timeout': 5,
+            'command_wrap': None
         }
         if config_files is None:
             config_files = ['~/.confidant', '/etc/confidant/config']
@@ -125,7 +131,8 @@ class ConfidantClient(object):
             'backoff': backoff,
             'assume_role': assume_role,
             'verify': verify,
-            'timeout': timeout
+            'timeout': timeout,
+            'command_wrap': command_wrap,
         }
         for key, val in args_config.items():
             if val is not None:

--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -27,7 +27,7 @@ logging.getLogger('urllib3').setLevel(logging.WARNING)
 boto3.set_stream_logger(level=logging.WARNING)
 logging.getLogger('botocore').setLevel(logging.WARNING)
 
-VERSION = '2.0.0'
+VERSION = '2.0.2'
 JSON_HEADERS = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 TOKEN_SKEW = 3
 TIME_FORMAT = "%Y%m%dT%H%M%SZ"

--- a/confidant_client/cli.py
+++ b/confidant_client/cli.py
@@ -550,7 +550,7 @@ def main():
         # then the following will be called:
         # 'aws-vault exec lisa -- confidant env --wrapped [command]
         if client.config.get('command_wrap') and not args.wrapped:
-            cmd = client.config.get('command_wrap').split(" ") + \
+            cmd = client.config.get('command_wrap').split() + \
                   ["confidant", args.subcommand, "--wrapped"] + \
                   sys.argv[2:]
             os.execvpe(cmd[0], cmd, os.environ)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="confidant-client",
-    version="2.2.1",
+    version="2.2.2",
     packages=find_packages(exclude=["test*"]),
     install_requires=[
         # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)


### PR DESCRIPTION
Usually calling `confidant` requires that we have an auth session with AWS.  This PR allows automatically wrapping `confidant` with an auth command.  

example before to fetch secrets:

```
aws-okta exec confidant-access -- confidant env --service my_service -- env
```

After defining  `command_wrap` in `~/.confidant`, we can just run:
```
confidant env --service my_service -- env
```

```
➜ cat ~/.confidant
default:
  url: https://confidant.lyft.net
  auth_key: alias/authnz
  auth_context:
    from: dliu@lyft.com
    to: confidant-production
    user_type: user
  token_cache_file: '/Users/dliu/.confidant_token_default'
  command_wrap: 'aws-okta exec zimride-confidant-access --'
  region: us-east-1
  ```

