### PR TITLE
Avoid passing in user AWS auth session to process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="confidant-client",
-    version="2.2.2",
+    version="2.2.3",
     packages=find_packages(exclude=["test*"]),
     install_requires=[
         # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)


### PR DESCRIPTION
AWS command line clients sets credentials as env vars.  We will only use these to auth to Confidant and it won't be passed into the process.  