### PR TITLE
Add ability to configure additional safety checks

### DIFF
--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -63,6 +63,8 @@ class ConfidantClient(object):
             verify=None,
             timeout=None,
             command_wrap=None,
+            command_safety_regex=None,
+            command_safety_msg=None,
             ):
         """Create a ConfidantClient object.
 
@@ -96,6 +98,12 @@ class ConfidantClient(object):
                 Useful when authentication to AWS needs to occur to generate
                 temporary credentials.  Examples: aws-vault, saml2aws
                 Default None.
+            command_safety_regex: define regex where if matched on service,
+              will require flag --force.  Ex. Useful for displaying
+              warnings if we're attempting to run commands against
+              production vs staging
+            command_safety_msg: Warning message to display if
+              command_safety_regex has been matched
         """
         # Set defaults
         self.config = {
@@ -111,7 +119,9 @@ class ConfidantClient(object):
             'backoff': 1,
             'verify': True,
             'timeout': 5,
-            'command_wrap': None
+            'command_wrap': None,
+            'command_safety_regex': None,
+            'command_safety_msg': None,
         }
         if config_files is None:
             config_files = ['~/.confidant', '/etc/confidant/config']
@@ -133,6 +143,8 @@ class ConfidantClient(object):
             'verify': verify,
             'timeout': timeout,
             'command_wrap': command_wrap,
+            'command_safety_regex': command_safety_regex,
+            'command_safety_msg': command_safety_msg,
         }
         for key, val in args_config.items():
             if val is not None:

--- a/confidant_client/cli.py
+++ b/confidant_client/cli.py
@@ -190,6 +190,15 @@ def _parse_args():
               'command_wrap defined in ~/.confidant'),
         required=False,
     )
+    env_parser.add_argument(
+        '--force',
+        action='store_true',
+        dest='force',
+        help=('If command_safety_regex in ~/.confidant is matched, '
+              '--force is required to run the command'),
+        default=False,
+        required=False,
+    )
     env_parser.set_defaults(
         decrypt_blind=False
     )
@@ -540,6 +549,16 @@ def main():
     ret = {'result': False}
 
     if args.subcommand == 'env':
+        safety_re = client.config.get('command_safety_regex')
+        if safety_re and re.search(safety_re, args.service) and not args.force:
+            msg = client.config.get(
+                'command_safety_msg',
+                'Fetching sensitive service credentials.  '
+                'Use --force to override'
+            )
+            logging.warning(msg)
+            sys.exit(-1)
+
         # If command_wrap is set in ~/.confidant then call 'confidant'
         # with the command_wrap and pass in flag --wrapped indicating
         # it's been wrapped so that we don't wrap again.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="confidant-client",
-    version="2.2.3",
+    version="2.2.4",
     packages=find_packages(exclude=["test*"]),
     install_requires=[
         # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)


### PR DESCRIPTION
While the command-line tool makes it easy to fetch credentials, in order to help avoid foot-guns, we add two new fields `command_safety_regex` and `command_safety_msg`.  Allows us to define a  regex that will display a warning if the regex matches.  As an example, this is useful if we want to display a warning message if we're fetching secrets from staging vs production.

Given the config:

```
default:
  url: https://confidant.lyft.net
  auth_key: alias/authnz-prod
  auth_context:
    from: dliu@lyft.com
    to: confidant-production
    user_type: user
  token_cache_file: '/Users/dliu/.confidant_token_default'
  command_wrap: 'aws-okta exec zimride-confidant-access --'
  command_safety_regex: '-production-iad$'
  command_safety_msg: 'You are fetching credentials from a production service, use "--force" to override'
  region: us-east-1
```

And the command to fetch production credentials will print the following warning message:
```
confidant env --service service-production-iad -- env
2022-04-24 12:03:15,398 root: WARNING You are fetching credentials from a production service, use "--force" to override
```