### PR TITLE
Support adding and removing credentials from services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.6
 exclude: '^docs/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  python: python3.6
 exclude: '^docs/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -1000,7 +1000,9 @@ class ConfidantClient(object):
             "account": response['service']['account'],
             "enabled": response['service']['enabled'],
             "credentials":  sorted(set(og_creds + credentials)),
-            "blind_credentials": sorted(set(og_blind_creds + blind_credentials)),
+            "blind_credentials": sorted(
+                set(og_blind_creds + blind_credentials)
+            ),
         }
         ret = {'result': False}
         try:
@@ -1017,9 +1019,9 @@ class ConfidantClient(object):
         return ret
 
     def remove_credentials_from_service(self,
-                                   credentials,
-                                   blind_credentials,
-                                   service):
+                                        credentials,
+                                        blind_credentials,
+                                        service):
         """Remove credentials from a service
         """
         if not credentials and not blind_credentials:
@@ -1041,7 +1043,9 @@ class ConfidantClient(object):
             "account": response['service']['account'],
             "enabled": response['service']['enabled'],
             "credentials":  sorted(set(og_creds) - set(credentials)),
-            "blind_credentials": sorted(set(og_blind_creds) - set(blind_credentials)),
+            "blind_credentials": sorted(
+                set(og_blind_creds) - set(blind_credentials)
+            ),
         }
 
         ret = {'result': False}

--- a/confidant_client/__init__.py
+++ b/confidant_client/__init__.py
@@ -995,28 +995,15 @@ class ConfidantClient(object):
             cred['id']
             for cred in response['service']['blind_credentials']
         ]
-        payload = {
-            "id": service,
-            "account": response['service']['account'],
-            "enabled": response['service']['enabled'],
-            "credentials":  sorted(set(og_creds + credentials)),
-            "blind_credentials": sorted(
+        return self._update_service(
+            account=response['service']['account'],
+            enabled=response['service']['enabled'],
+            service=service,
+            credentials=sorted(set(og_creds + credentials)),
+            blind_credentials=sorted(
                 set(og_blind_creds + blind_credentials)
-            ),
-        }
-        ret = {'result': False}
-        try:
-            self._execute_request(
-                'put',
-                '{0}/v1/services/{1}'.format(self.config['url'], service),
-                json=payload
             )
-        except RequestExecutionError:
-            logging.exception('Error with executing request')
-            return ret
-
-        ret['result'] = True
-        return ret
+        )
 
     def remove_credentials_from_service(self,
                                         credentials,
@@ -1037,17 +1024,29 @@ class ConfidantClient(object):
             cred['id']
             for cred in response['service']['blind_credentials']
         ]
+        return self._update_service(
+            account=response['service']['account'],
+            enabled=response['service']['enabled'],
+            service=service,
+            credentials=sorted(set(og_creds) - set(credentials)),
+            blind_credentials=sorted(
+                set(og_blind_creds) - set(blind_credentials)
+            )
+        )
 
+    def _update_service(self,
+                        account,
+                        enabled,
+                        credentials,
+                        blind_credentials,
+                        service):
         payload = {
             "id": service,
-            "account": response['service']['account'],
-            "enabled": response['service']['enabled'],
-            "credentials":  sorted(set(og_creds) - set(credentials)),
-            "blind_credentials": sorted(
-                set(og_blind_creds) - set(blind_credentials)
-            ),
+            "account": account,
+            "enabled": enabled,
+            "credentials":  credentials,
+            "blind_credentials": blind_credentials,
         }
-
         ret = {'result': False}
         try:
             self._execute_request(

--- a/confidant_client/cli.py
+++ b/confidant_client/cli.py
@@ -529,6 +529,53 @@ def _parse_args():
         'list_cas'
     )
 
+    add_creds_to_service_parser = subparsers.add_parser(
+        'add_creds'
+    )
+    add_creds_to_service_parser.add_argument(
+        '--cred-ids',
+        type=str,
+        nargs='+',
+        dest='cred_ids',
+        default=[]
+    )
+    add_creds_to_service_parser.add_argument(
+        '--blind-cred-ids',
+        type=str,
+        nargs='+',
+        dest='blind_cred_ids',
+        default=[],
+    )
+    add_creds_to_service_parser.add_argument(
+        '--service-id',
+        type=str,
+        dest='service_id'
+    )
+
+    rm_creds_from_service_parser = subparsers.add_parser(
+        'remove_creds'
+    )
+    rm_creds_from_service_parser.add_argument(
+        '--cred-ids',
+        type=str,
+        nargs='+',
+        dest='cred_ids',
+        default=[]
+    )
+    rm_creds_from_service_parser.add_argument(
+        '--blind-cred-ids',
+        type=int,
+        nargs='+',
+        dest='blind_cred_ids',
+        default=[]
+    )
+    rm_creds_from_service_parser.add_argument(
+        '--service-id',
+        type=str,
+        dest='service_id',
+        required=True,
+    )
+
     return parser.parse_args()
 
 
@@ -704,6 +751,26 @@ def main():
     elif args.subcommand == 'list_cas':
         try:
             ret = client.list_cas()
+        except Exception:
+            logging.exception('An unexpected general error occurred.')
+
+
+    elif args.subcommand == 'add_creds':
+        try:
+            ret = client.add_credentials_to_service(
+                credentials=args.cred_ids,
+                blind_credentials=args.blind_cred_ids,
+                service=args.service_id
+            )
+        except Exception:
+            logging.exception('An unexpected general error occurred.')
+    elif args.subcommand == 'remove_creds':
+        try:
+            ret = client.remove_credentials_from_service(
+                credentials=args.cred_ids,
+                blind_credentials=args.blind_cred_ids,
+                service=args.service_id
+            )
         except Exception:
             logging.exception('An unexpected general error occurred.')
 

--- a/confidant_client/cli.py
+++ b/confidant_client/cli.py
@@ -506,7 +506,7 @@ def _parse_args():
     )
     ca_get_certificate_from_csr_parser.add_argument(
         '--csr-file',
-        help=('A cerftificate signing request (CSR) file to issue a certificate'
+        help=('A certificate signing request (CSR) file to issue a certificate'
               'from.'),
     )
     ca_get_certificate_from_csr_parser.add_argument(
@@ -530,14 +530,16 @@ def _parse_args():
     )
 
     add_creds_to_service_parser = subparsers.add_parser(
-        'add_creds'
+        'add_creds',
+        help=('Add credential ids to a service'),
     )
     add_creds_to_service_parser.add_argument(
         '--cred-ids',
         type=str,
         nargs='+',
         dest='cred_ids',
-        default=[]
+        default=[],
+        help=('list of credential ids, separated by whitespace'),
     )
     add_creds_to_service_parser.add_argument(
         '--blind-cred-ids',
@@ -545,29 +547,33 @@ def _parse_args():
         nargs='+',
         dest='blind_cred_ids',
         default=[],
+        help=('list of credential ids, separated by whitespace'),
     )
     add_creds_to_service_parser.add_argument(
         '--service-id',
         type=str,
-        dest='service_id'
+        dest='service_id',
     )
 
     rm_creds_from_service_parser = subparsers.add_parser(
-        'remove_creds'
+        'remove_creds',
+        help=('Remove credential ids to a service'),
     )
     rm_creds_from_service_parser.add_argument(
         '--cred-ids',
         type=str,
         nargs='+',
         dest='cred_ids',
-        default=[]
+        default=[],
+        help=('list of credential ids, separated by whitespace'),
     )
     rm_creds_from_service_parser.add_argument(
         '--blind-cred-ids',
         type=int,
         nargs='+',
         dest='blind_cred_ids',
-        default=[]
+        default=[],
+        help=('list of credential ids, separated by whitespace'),
     )
     rm_creds_from_service_parser.add_argument(
         '--service-id',
@@ -753,8 +759,6 @@ def main():
             ret = client.list_cas()
         except Exception:
             logging.exception('An unexpected general error occurred.')
-
-
     elif args.subcommand == 'add_creds':
         try:
             ret = client.add_credentials_to_service(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="confidant-client",
-    version="2.3.2",
+    version="2.4.0",
     packages=find_packages(exclude=["test*"]),
     install_requires=[
         # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)

--- a/tests/unit/confidant_client/client_test.py
+++ b/tests/unit/confidant_client/client_test.py
@@ -770,8 +770,8 @@ class ClientTest(unittest.TestCase):
 
         self.assertEqual(
             client.add_credentials_to_service(
-                credentials=['b','c'],
-                blind_credentials=['x','y','z'],
+                credentials=['b', 'c'],
+                blind_credentials=['x', 'y', 'z'],
                 service='confidant-development'
             ),
             {'result': True}

--- a/tests/unit/confidant_client/client_test.py
+++ b/tests/unit/confidant_client/client_test.py
@@ -755,7 +755,8 @@ class ClientTest(unittest.TestCase):
         )
         token_mock = MagicMock()
         client._get_token = token_mock
-        client.request_session.request = mock_200
+        client._update_service = MagicMock()
+        client._update_service.return_value = {'result': True}
         client.get_service = MagicMock()
         client.get_service.return_value = {
             'result': True,
@@ -776,20 +777,13 @@ class ClientTest(unittest.TestCase):
             ),
             {'result': True}
         )
-        client.request_session.request.assert_called_with(
-            'PUT',
-            'http://localhost//v1/services/confidant-development',
-            auth=('2/service/confidant-unittest', token_mock()),
-            allow_redirects=False,
-            timeout=5,
-            data=None,
-            json={
-                'id': 'confidant-development',
-                'account': None,
-                'enabled': True,
-                'credentials': ['a', 'b', 'c'],
-                'blind_credentials': ['x', 'y', 'z']
-            }
+
+        client._update_service.assert_called_with(
+            account=None,
+            enabled=True,
+            service='confidant-development',
+            credentials=['a', 'b', 'c'],
+            blind_credentials=['x', 'y', 'z']
         )
 
     def test_remove_credentials_to_service(self):
@@ -802,7 +796,8 @@ class ClientTest(unittest.TestCase):
         )
         token_mock = MagicMock()
         client._get_token = token_mock
-        client.request_session.request = mock_200
+        client._update_service = MagicMock()
+        client._update_service.return_value = {'result': True}
         client.get_service = MagicMock()
         client.get_service.return_value = {
             'result': True,
@@ -822,6 +817,36 @@ class ClientTest(unittest.TestCase):
             ),
             {'result': True}
         )
+        client._update_service.assert_called_with(
+            account=None,
+            enabled=True,
+            service='confidant-development',
+            credentials=['b', 'c'],
+            blind_credentials=['y', 'z']
+        )
+
+    def test_update_service(self):
+        client = confidant_client.ConfidantClient(
+            'http://localhost/',
+            'alias/authnz-testing',
+            {'from': 'confidant-unittest',
+             'to': 'test',
+             'user_type': 'service'},
+        )
+        token_mock = MagicMock()
+        client._get_token = token_mock
+        client.request_session.request = mock_200
+
+        self.assertEqual(
+            client._update_service(
+                account=None,
+                enabled=True,
+                credentials=['a', 'b', 'c'],
+                blind_credentials=['x', 'y', 'z'],
+                service='confidant-development'
+            ),
+            {'result': True}
+        )
         client.request_session.request.assert_called_with(
             'PUT',
             'http://localhost//v1/services/confidant-development',
@@ -833,7 +858,7 @@ class ClientTest(unittest.TestCase):
                 'id': 'confidant-development',
                 'account': None,
                 'enabled': True,
-                'credentials': ['b', 'c'],
-                'blind_credentials': ['y', 'z']
+                'credentials': ['a', 'b', 'c'],
+                'blind_credentials': ['x', 'y', 'z']
             }
         )


### PR DESCRIPTION
```
confidant add_creds -h
usage: cli.py add_creds [-h] [--cred-ids CRED_IDS [CRED_IDS ...]] [--blind-cred-ids BLIND_CRED_IDS [BLIND_CRED_IDS ...]] [--service-id SERVICE_ID]

options:
  -h, --help            show this help message and exit
  --cred-ids CRED_IDS [CRED_IDS ...]
                        list of credential ids, separated by whitespace
  --blind-cred-ids BLIND_CRED_IDS [BLIND_CRED_IDS ...]
                        list of credential ids, separated by whitespace
  --service-id SERVICE_ID
```

ex:
```
confidant add_creds --service-id service-development --cred-ids cred_id_1 cred_id_2
confidant remove_creds --service-id service-development --cred-ids cred_id_1 cred_id_2
```

The command saves the original credentials and attaches/removes credentials to the service, in order to prevent foot-guns of accidentally removing all credentials from a service.