### PR TITLE
hotfix - pass in resource_id

### DIFF
--- a/confidant_client/cli.py
+++ b/confidant_client/cli.py
@@ -795,7 +795,7 @@ def main():
             logging.exception('An unexpected general error occurred.')
     elif args.subcommand == 'get_jwt':
         try:
-            ret = client.get_jwt(args.environment)
+            ret = client.get_jwt(args.environment, args.resource_id)
         except Exception:
             logging.exception('An unexpected general error occurred.')
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="confidant-client",
-    version="2.5.1",
+    version="2.5.2",
     packages=find_packages(exclude=["test*"]),
     install_requires=[
         # Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK)


### PR DESCRIPTION
Fixes:

```bash
Traceback (most recent call last):
  File "/Users/dliu/src/python-confidant-client/confidant_client/cli.py", line 798, in main
    ret = client.get_jwt(args.environment)
TypeError: ConfidantClient.get_jwt() missing 1 required positional argument: 'resource_id'
```