### PR TITLE
unpin py310 patch revision

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.14
+          python-version: 3.10.x
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.14
+          python-version: 3.10.x
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist


### PR DESCRIPTION
The PR fixes the pypi release pipeline, see https://github.com/lyft/python-confidant-client/actions/runs/12261349681/job/34208159517